### PR TITLE
refactor(neovim): binds updated

### DIFF
--- a/roles/dotfiles/files/nvim/.config/nvim/init.lua
+++ b/roles/dotfiles/files/nvim/.config/nvim/init.lua
@@ -17,6 +17,7 @@ require('plugins/formatter-config')
 require('plugins/which-key-config')
 require('lsp')
 require('options')
+require('binds')
 
 -- UNCOMMENT FOR DEBUG MESSAGES
 -- print('[COMPLETED]')

--- a/roles/dotfiles/files/nvim/.config/nvim/lua/binds.lua
+++ b/roles/dotfiles/files/nvim/.config/nvim/lua/binds.lua
@@ -1,0 +1,92 @@
+-- <leader> = space
+vim.g.mapleader = " "
+
+local opts = {noremap = true, silent = true}
+
+-- # GLOBAL BINDS
+vim.api.nvim_set_keymap('n', ']q', ':cn<CR>', opts) -- go to next item in list
+vim.api.nvim_set_keymap('n', '[q', ':cp<CR>', opts) -- go to previous item in list
+
+-- # LEADER BINDS
+-- COMMAND PALLETTE = `p`
+vim.api.nvim_set_keymap('n', '<Leader>p', '<cmd>lua require("telescope.builtin").commands()<CR>', opts) -- opens the command pallette
+
+-- CURSOR MOVEMENT = `h` + `j` + `k` + `l`
+vim.api.nvim_set_keymap('n', '<leader>h', ':FocusSplitLeft<CR>', opts) -- move cursor to left window
+vim.api.nvim_set_keymap('n', '<leader>j', ':FocusSplitDown<CR>', opts) -- move cursor to bottom window
+vim.api.nvim_set_keymap('n', '<leader>k', ':FocusSplitUp<CR>', opts) -- move cursor to top window
+vim.api.nvim_set_keymap('n', '<leader>l', ':FocusSplitRight<CR>', opts) -- move cursor to right window
+
+-- # GROUPED BINDS
+-- BUFFERS = `b`
+vim.api.nvim_set_keymap('n', '<leader>bw', ':w<CR>', opts) -- write buffer
+vim.api.nvim_set_keymap('n', '<leader>br', ':e<CR>', opts) -- reload buffer
+vim.api.nvim_set_keymap('n', '<leader>bf', ':Format<CR>', opts) -- runs formatter/linter on current buffer
+vim.api.nvim_set_keymap('n', '<Leader>bs', ':setlocal spell! spelllang=en_gb,en_us<CR>', opts) -- toggle spellcheck on current buffer
+vim.api.nvim_set_keymap('n', '<Leader>b/', '<cmd>lua require("telescope.builtin").current_buffer_fuzzy_find()<CR>', opts) -- open fuzzy find within current buffer
+
+-- EXPLORER = `e`
+vim.api.nvim_set_keymap('n', '<leader>ee', ':Explore<CR>', opts) -- open explorer in current window
+vim.api.nvim_set_keymap('n', '<leader>et', ':Texplore<CR>', opts) -- open explorer in new tab
+
+-- FILES = `f`
+vim.api.nvim_set_keymap('n', '<leader>ff', '<cmd>lua require("telescope.builtin").find_files()<CR>', opts) -- open file finder
+vim.api.nvim_set_keymap('n', '<leader>fg', '<cmd>lua require("telescope.builtin").git_files()<CR>', opts) -- open git file finder
+vim.api.nvim_set_keymap('n', '<leader>fb', '<cmd>lua require("telescope").extensions.file_browser.file_browser()<CR>', opts) -- open file browser on current working directory
+vim.api.nvim_set_keymap('n', '<leader>fd', '<cmd>lua require("telescope").extensions.file_browser.file_browser({ cwd = require("telescope.utils").buffer_dir() })<CR>', opts) -- open file browser on buffer directory
+vim.api.nvim_set_keymap('n', '<Leader>f/', '<cmd>lua require("telescope.builtin").live_grep()<CR>', opts) -- open fuzzy find accross current working directory
+
+-- FUZZY SEARCHING = `/`
+vim.api.nvim_set_keymap('n', '<Leader>/f', '<cmd>lua require("telescope.builtin").live_grep()<CR>', opts) -- open fuzzy find accross current working directory
+vim.api.nvim_set_keymap('n', '<Leader>/b', '<cmd>lua require("telescope.builtin").current_buffer_fuzzy_find()<CR>', opts) -- open fuzzy find within current buffer
+
+-- GIT = `g`
+vim.api.nvim_set_keymap('n', '<leader>gg', ':term lazygit<CR>:startinsert<CR>', opts) -- open git client in current window
+vim.api.nvim_set_keymap('n', '<leader>gh', ':!gh', opts) -- open a github cli statement
+vim.api.nvim_set_keymap('n', '<leader>gc', ':!git', opts) -- open a git cli statement
+vim.api.nvim_set_keymap('n', '<leader>gt', ':tabnew<CR>:term lazygit<CR>:startinsert<CR>', opts) -- open git client in new tab
+vim.api.nvim_set_keymap('n', '<leader>gf', '<cmd>lua require("telescope.builtin").git_files()<CR>', opts) -- browse git files
+vim.api.nvim_set_keymap('n', '<leader>gb', '<cmd>lua require("telescope.builtin").git_branches()<CR>', opts) -- browse git branches
+vim.api.nvim_set_keymap('n', '<leader>gs', '<cmd>lua require("telescope.builtin").git_status()<CR>', opts) -- browse git status
+
+-- INTERFACE = `i`
+vim.api.nvim_set_keymap('n', '<leader>il', ':set background=light<CR>:highlight clear SignColumn<CR>:highlight clear Folded<CR>', opts) -- set theme to light
+vim.api.nvim_set_keymap('n', '<leader>id', ':set background=dark<CR>:highlight clear SignColumn<CR>:highlight clear Folded<CR>', opts) -- set theme to dark
+vim.api.nvim_set_keymap('n', '<leader>in', ':set relativenumber!<CR>', opts) -- toggle relative line numbers
+vim.api.nvim_set_keymap('n', '<leader>ic', ':set list!<CR>', opts) -- toggle display unprintable chars
+
+-- LANGUAGE SERVER PROTOCOL = `s`
+-- vim.api.nvim_set_keymap('n', '<leader>ss', '<cmd>lua require("telescope.builtin").lsp_document_diagnostics()<CR>', opts) -- show diagnostics
+-- vim.api.nvim_set_keymap('n', '<Leader>sd', '<cmd>lua require("telescope.builtin").lsp_definitions()<CR>', opts) -- go to definition
+-- vim.api.nvim_set_keymap('n', '<Leader>st', '<cmd>lua require("telescope.builtin").lsp_type_definitions()<CR>', opts) -- go to type definition
+-- vim.api.nvim_set_keymap('n', '<Leader>si', '<cmd>lua require("telescope.builtin").lsp_implementations()<CR>', opts) -- go to implementation
+-- vim.api.nvim_set_keymap('n', '<Leader>sr', '<cmd>lua require("telescope.builtin").lsp_references()<CR>', opts) -- show references
+-- vim.api.nvim_set_keymap('n', '<leader>sa', '<cmd>lua require("telescope.builtin").lsp_code_actions()<CR>', opts) -- show code actions
+-- vim.api.nvim_set_keymap('n', '<Leader>sh', '<cmd>lua vim.lsp.buf.hover()<CR>', opts) -- cursor hover
+-- vim.api.nvim_set_keymap('n', '<leader>sn', '<cmd>lua vim.lsp.buf.rename()<CR>', opts) -- rename symbol
+-- vim.api.nvim_set_keymap('n', '<leader>sj', '<cmd>lua vim.lsp.diagnostic.goto_next()<CR>', opts) -- go to next diagnostic
+-- vim.api.nvim_set_keymap('n', '<leader>sk', '<cmd>lua vim.lsp.diagnostic.goto_prev()<CR>', opts) -- go to previous diagnostic
+
+-- TABS = `t`
+vim.api.nvim_set_keymap('n', '<leader>tt', ':tabnew<CR>', opts) -- open new tab
+vim.api.nvim_set_keymap('n', '<leader>tc', ':tabnew<CR>:term<CR>:startinsert<CR>', opts) -- open new tab with terminal console
+vim.api.nvim_set_keymap('n', '<leader>te', ':tabnew<CR>:Ex<CR>', opts) -- open new tab with explorer
+vim.api.nvim_set_keymap('n', '<leader>tg', ':tabnew<CR>:term lazygit<CR>:startinsert<CR>', opts) -- open new tab with git client
+
+-- TERMINAL CONSOLE = `c`
+vim.api.nvim_set_keymap('n', '<leader>cc', ':term<CR>:startinsert<CR>', opts) -- open terminal console in current window
+vim.api.nvim_set_keymap('n', '<leader>ct', ':tabnew<CR>:term<CR>:startinsert<CR>', opts) -- open terminal console in new tab
+vim.api.nvim_set_keymap('t', '<Esc><Esc>', '<C-\\><C-n>', opts) -- normal mode within terminal window
+
+-- WINDOWS = `w`
+vim.api.nvim_set_keymap('n', '<leader>wm', '<C-W>_<C-W>|', opts) -- maximise window
+vim.api.nvim_set_keymap('n', '<leader>we', '<C-W>=', opts) -- equalise windows
+vim.api.nvim_set_keymap('n', '<leader>wq', ':q<CR>', opts) -- quit window
+vim.api.nvim_set_keymap('n', '<leader>wo', '<C-W>o', opts) -- close all other windows
+vim.api.nvim_set_keymap('n', '<leader>wh', '<C-W>H', opts) -- move window to left
+vim.api.nvim_set_keymap('n', '<leader>wj', '<C-W>J', opts) -- move window to bottom
+vim.api.nvim_set_keymap('n', '<leader>wk', '<C-W>K', opts) -- move window to top
+vim.api.nvim_set_keymap('n', '<leader>wl', '<C-W>L', opts) -- move window to right
+
+-- UNCOMMENT FOR DEBUG MESSAGES
+-- print('- binds.lua...OK!')

--- a/roles/dotfiles/files/nvim/.config/nvim/lua/plugins/which-key-config.lua
+++ b/roles/dotfiles/files/nvim/.config/nvim/lua/plugins/which-key-config.lua
@@ -1,143 +1,122 @@
--- TODO: look at requiring in setup from here instead
-local binds = {
-    -- CURSOR MOVEMENT = `h` + `j` + `k` + `l`
-    {'n', '<leader>h', ':FocusSplitLeft<CR>'}, -- move cursor to left window
-    {'n', '<leader>j', ':FocusSplitDown<CR>'}, -- move cursor to bottom window
-    {'n', '<leader>k', ':FocusSplitUp<CR>'}, -- move cursor to top window
-    {'n', '<leader>l', ':FocusSplitRight<CR>'}, -- move cursor to right window
-
-    -- TERMINAL CONSOLE = `c`
-    {'t', '<Esc><Esc>', '<C-\\><C-n>'}, -- normal mode within terminal window
-
-    -- FILES = `f`
-    {'n', '<Leader>f/', '<cmd>lua require("telescope.builtin").live_grep()<CR>'}, -- open fuzzy find accross current working directory
-
-    -- BUFFERS = `b`
-    {'n', '<Leader>b/', '<cmd>lua require("telescope.builtin").current_buffer_fuzzy_find()<CR>'}, -- open fuzzy find within current buffer
-
-    -- FUZZY SEARCHING = `/`
-    {'n', '<Leader>/f', '<cmd>lua require("telescope.builtin").live_grep()<CR>'}, -- open fuzzy find accross current working directory
-    {'n', '<Leader>/b', '<cmd>lua require("telescope.builtin").current_buffer_fuzzy_find()<CR>'}, -- open fuzzy find within current buffer
-
-    -- TELESCOPE PICKERS = `p`
-    {'n', '<Leader>p', '<cmd>lua require("telescope.builtin").builtin(require("telescope.themes").get_dropdown())<CR>'}, -- opens list of Telescope pickers
-
-    -- QUICKFIX LIST = `q`
-    {'n', '<Leader>qj', ':cn<CR>'}, -- go to next item in list
-    {'n', '<Leader>qk', ':cp<CR>'}, -- go to previous item in list
-}
--- <leader> = space
-
-vim.g.mapleader = " "
-
-local opts = {noremap = true, silent = true}
-
-for i = 1, #binds do
-    local mode = binds[i][1]
-    local lhs = binds[i][2]
-    local rhs = binds[i][3]
-
-    vim.api.nvim_set_keymap(mode, lhs, rhs, opts)
-end
-
 local wk = require('which-key')
--- TODO: top level cursor movement keybinds from binds.lua
--- TODO: top level telescope pickers keybinds from binds.lua
--- TODO: top level quickfix keybinds from binds.lua
 
 wk.register({
-  i = {
-    name = 'interface',
-    l = { ':set background=light<CR>:highlight clear SignColumn<CR>:highlight clear Folded<CR>', 'set theme to light'},
-    d = { ':set background=dark<CR>:highlight clear SignColumn<CR>:highlight clear Folded<CR>', 'set theme to dark'},
-    n = { ':set relativenumber!<CR>', 'toggle relative line numbers'},
-    c = { ':set list!<CR>', 'toggle display unprintable chars'},
-  },
+  -- # LEADER BINDS
+  ['<leader>'] = {
+    name = 'LEADER BINDS',
+    -- COMMAND PALLETTE = `p`
+    p = {'command pallette'},
 
-  w = {
-    name = 'windows',
-    m = { '<C-W>_<C-W>|', 'maximise window' },
-    e = { '<C-W>=', 'equalise windows' },
-    q = { ':q<CR>', 'quit window' },
-    o = { '<C-W>o', 'close all other windows' },
-    h = { '<C-W>H', 'move window to left' },
-    j = { '<C-W>J', 'move window to bottom' },
-    k = { '<C-W>K', 'move window to top' },
-    l = { '<C-W>L', 'move window to right' },
-    z = { ':ZenMode<CR>', 'toggle zen mode' },
-  },
+    -- CURSOR MOVEMENT = `h` + `j` + `k` + `l`
+    h = {'cursor left'},
+    j = {'cursor down'},
+    k = {'cursor up'},
+    l = {'cursor right'},
 
-  t = {
-    name = 'tabs',
-    t = { ':tabnew<CR>', 'open new tab' },
-    c = { ':tabnew<CR>:term<CR>:startinsert<CR>', 'open new tab with terminal console' },
-    e = { ':tabnew<CR>:Ex<CR>', 'open new tab with explorer' },
-    g = { ':tabnew<CR>:term lazygit<CR>:startinsert<CR>', 'open new tab with git client' },
-  },
+    -- # GROUPED BINDS
+    -- BUFFERS = `b`
+    b = {
+      name = 'BUFFERS',
+      w = { 'write buffer' },
+      r = { 'reload buffer' },
+      f = { 'runs formatter/linter on current buffer' },
+      s = { 'toggle spellcheck on current buffer' },
+      ['/'] = { 'grep buffer' },
+    },
 
-  c = {
-    name = 'console',
-    c = { ':term<CR>:startinsert<CR>', 'open terminal console in current window' },
-    t = { ':tabnew<CR>:term<CR>:startinsert<CR>', 'open terminal console in new tab' },
-    -- TODO: fix this
-    -- {'t', '<Esc><Esc>', '<C-\\><C-n>'}, -- normal mode within terminal window
-  },
+    -- EXPLORER = `e`
+    e = {
+      name = 'EXPLORER',
+      e = { 'open explorer in current window' },
+      t = { 'open explorer in new tab' },
+    },
 
-  e = {
-    name = 'explorer',
-    e = { ':Explore<CR>', 'open explorer in current window' },
-    t = { ':Texplore<CR>', 'open explorer in new tab' },
-  },
+    -- FILES = `f`
+    f = {
+      name = 'FILES',
+      f = { 'find file' },
+      g = { 'find git file' },
+      b = { 'file browser (project directory)' },
+      d = { 'file browser (current directory)' },
+      ['/'] = { 'Grep Files' },
+    },
 
-  g = {
-    name = 'git',
-    g = { ':term lazygit<CR>:startinsert<CR>', 'open git client in current window' },
-    h = { ':!gh', 'open a github cli statement' },
-    c = { ':!git', 'open a git cli statement' },
-    t = { ':tabnew<CR>:term lazygit<CR>:startinsert<CR>', 'open git client in new tab' },
-    f = { '<cmd>lua require("telescope.builtin").git_files()<CR>', 'browse git files' },
-    b = { '<cmd>lua require("telescope.builtin").git_branches()<CR>', 'browse git branches' },
-    s = { '<cmd>lua require("telescope.builtin").git_status()<CR>', 'browse git status' },
-  },
+    -- FUZZY SEARCHING = `/`
+    ['/'] = {
+      name = 'FUZZY SEARCHING',
+      f = { 'grep files' },
+      b = { 'grep buffer' },
+    },
 
-  f = {
-    name = 'file',
-    f = { '<cmd>lua require("telescope.builtin").find_files()<CR>', 'Find File' },
-    g = { '<cmd>lua require("telescope.builtin").git_files()<CR>', 'Find Git File' },
-    b = { '<cmd>lua require("telescope").extensions.file_browser.file_browser()<CR>', 'File Browser (project directory)' },
-    d = { '<cmd>lua require("telescope").extensions.file_browser.file_browser({ cwd = require("telescope.utils").buffer_dir() })<CR>', 'File Browser (current directory)' },
-    -- TODO: fix this
-    -- / = { '<cmd>lua require("telescope.builtin").live_grep()', 'Grep Files' },
-  },
+    -- GIT = `g`
+    g = {
+      name = 'GIT',
+      g = { 'open git client in current window' },
+      h = { 'open a github cli statement' },
+      c = { 'open a git cli statement' },
+      t = { 'open git client in new tab' },
+      f = { 'browse git files' },
+      b = { 'browse git branches' },
+      s = { 'browse git status' },
+    },
 
-  b = {
-    name = 'buffer',
-    w = { ':w<CR>', 'write buffer' },
-    r = { ':e<CR>', 'reload buffer' },
-    f = { ':Format<CR>', 'runs formatter/linter on current buffer' },
-    s = { ':setlocal spell! spelllang=en_gb,en_us<CR>', 'toggle spellcheck on current buffer' },
-    -- TODO: fix this
-    -- / = { '<cmd><cmd>lua require("telescope.builtin").current_buffer_fuzzy_find()<CR>', 'open fuzzy find within current buffer' },
-  },
+    -- INTERFACE = `i`
+    i = {
+      name = 'INTERFACE',
+      l = { 'set theme to light'},
+      d = { 'set theme to dark'},
+      n = { 'toggle relative line numbers'},
+      c = { 'toggle display unprintable chars'},
+    },
 
--- TODO: migrate fuzzy keybinds from binds.lua
+    -- LANGUAGE SERVER PROTOCOL = `s`
+    -- s = {
+    --   name = 'language server',
+    --   s = { 'show diagnostics' },
+    --   -- TODO: update telescope diagnostic lists (potentially requires new bind namespace?)
+    --   -- s = { '<cmd>lua require("telescope.builtin").lsp_document_diagnostics()<CR>', 'show diagnostics' },
+    --   d = { 'go to definition' },
+    --   t = { 'go to type definition' },
+    --   i = { 'go to implementation' },
+    --   r = { 'show references' },
+    --   a = { 'show code actions' },
+    --   h = { 'cursor hover' },
+    --   n = { 'rename symbol' },
+    --   j = { 'go to next diagnostic' },
+    --   k = { 'go to previous diagnostic' },
+    -- },
 
-  s = {
-    name = 'language server',
-    s = { '<cmd>lua vim.diagnostic.open_float()<CR>', 'show diagnostics' },
-    -- TODO: update telescope diagnostic lists (potentially requires new bind namespace?)
-    -- s = { '<cmd>lua require("telescope.builtin").lsp_document_diagnostics()<CR>', 'show diagnostics' },
-    d = { '<cmd>lua require("telescope.builtin").lsp_definitions()<CR>', 'go to definition' },
-    t = { '<cmd>lua require("telescope.builtin").lsp_type_definitions()<CR>', 'go to type definition' },
-    i = { '<cmd>lua require("telescope.builtin").lsp_implementations()<CR>', 'go to implementation' },
-    r = { '<cmd>lua require("telescope.builtin").lsp_references()<CR>', 'show references' },
-    a = { '<cmd>lua require("telescope.builtin").lsp_code_actions()<CR>', 'show code actions' },
-    h = { '<cmd>lua vim.lsp.buf.hover()<CR>', 'cursor hover' },
-    n = { '<cmd>lua vim.lsp.buf.rename()<CR>', 'rename symbol' },
-    j = { '<cmd>lua vim.diagnostic.goto_next()<CR>', 'go to next diagnostic' },
-    k = { '<cmd>lua vim.diagnostic.goto_prev()<CR>', 'go to previous diagnostic' },
+    -- TABS = `t`
+    t = {
+      name = 'TABS',
+      t = { 'open new tab' },
+      c = { 'open new tab with terminal console' },
+      e = { 'open new tab with explorer' },
+      g = { 'open new tab with git client' },
+    },
+
+    -- TERMINAL CONSOLE = `c`
+    c = {
+      name = 'CONSOLE',
+      c = { 'open terminal console in current window' },
+      t = { 'open terminal console in new tab' },
+    },
+
+    -- WINDOWS = `w`
+    w = {
+      name = 'WINDOWS',
+      m = { 'maximise window' },
+      e = { 'equalise windows' },
+      q = { 'quit window' },
+      o = { 'close all other windows' },
+      h = { 'move window to left' },
+      j = { 'move window to bottom' },
+      k = { 'move window to top' },
+      l = { 'move window to right' },
+      z = { 'toggle zen mode' },
+    },
   },
-}, { prefix = '<leader>' })
+})
 
 -- UNCOMMENT FOR DEBUG MESSAGES
 -- print('- plugins/which-key-config.lua ...OK!')

--- a/roles/dotfiles/tasks/main.yml
+++ b/roles/dotfiles/tasks/main.yml
@@ -45,6 +45,7 @@
     - { package: 'newsboat', path: '.config/newsboat/urls' }
     - { package: 'nvim', path: '.config/nvim/init.lua' }
     - { package: 'nvim', path: '.config/nvim/lua/lsp.lua' }
+    - { package: 'nvim', path: '.config/nvim/lua/binds.lua' }
     - { package: 'nvim', path: '.config/nvim/lua/options.lua' }
     - { package: 'nvim', path: '.config/nvim/lua/plugins.lua' }
     - { package: 'nvim', path: '.config/nvim/lua/plugins/formatter-config.lua' }


### PR DESCRIPTION
Binds have been updated to remove the dependency on the `which-key`
plugin. The `binds` file has been bought back and the role of
`which-key` has been rolled back to focusing on just labelling keybinds
within the interface.
